### PR TITLE
LogError only if `UnityFFBNative` method return non-zero value

### DIFF
--- a/Runtime/UnityFFB.cs
+++ b/Runtime/UnityFFB.cs
@@ -250,7 +250,10 @@ namespace UnityFFB
             if (constantForceEnabled)
             {
                 int hresult = UnityFFBNative.UpdateEffectGain(EffectsType.ConstantForce, gainPercent);
-                Debug.LogError($"[UnityFFB] UpdateEffectGain Failed: 0x{hresult.ToString("x")} {WinErrors.GetSystemMessage(hresult)}");
+                if (hresult != 0)
+                {
+                    Debug.LogError($"[UnityFFB] UpdateEffectGain Failed: 0x{hresult.ToString("x")} {WinErrors.GetSystemMessage(hresult)}");
+                }
             }
 #endif
         }

--- a/Runtime/UnityFFB.cs
+++ b/Runtime/UnityFFB.cs
@@ -215,7 +215,10 @@ namespace UnityFFB
                                     springConditions[i].positiveSaturation = 10000;
                                 }
                                 hresult = UnityFFBNative.UpdateSpring(springConditions);
-                                Debug.LogError($"[UnityFFB] UpdateSpringForce Failed: 0x{hresult.ToString("x")} {WinErrors.GetSystemMessage(hresult)}");
+                                if (hresult != 0)
+                                {
+                                    Debug.LogError($"[UnityFFB] UpdateSpringForce Failed: 0x{hresult.ToString("x")} {WinErrors.GetSystemMessage(hresult)}");
+                                }
                             }
                             else
                             {


### PR DESCRIPTION
Add missing `hresult` check on non-zero value in `UnityFFBNative.UpdateEffectGain()` and `SelectDevice()` method calls.